### PR TITLE
Updating lombok for compatability with java 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.3'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.3'
     implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
-    compileOnly 'org.projectlombok:lombok:1.18.18'
-    annotationProcessor 'org.projectlombok:lombok:1.18.18'
+    compileOnly 'org.projectlombok:lombok:1.18.24'
+    annotationProcessor 'org.projectlombok:lombok:1.18.24'
 }
 
 group = 'io.github.dschanoeh'


### PR DESCRIPTION
The old Lombok version does not support the new internal access issues. So this version bump allows to run homie-java in a modern JVM.